### PR TITLE
Properly toggle aria-expanded for Firefox

### DIFF
--- a/app/static/toggleFeatured.js
+++ b/app/static/toggleFeatured.js
@@ -1,11 +1,11 @@
 function toggleFeatured() {
 	var content = this.nextElementSibling;
 	if (content.style.display == "none") {
+		this.setAttribute("aria-expanded", true);
 		content.style.display = "block";
-		this.ariaExpanded = true;
 	} else {
+		this.setAttribute("aria-expanded", false);
 		content.style.display = "none";
-		this.ariaExpanded = false;
 	}
 }
 var buttons = document.querySelectorAll('.collapsible');

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -14,7 +14,7 @@
 		No video is hosted on this site. Nobody profits from this endeavour. It operates on donations from the small userbase purely in order to maintain the site.</p>
 		<h2>Featured</h2>
 		{%for item in featured%}
-			<button class="collapsible" aria-controls="content" aria-expanded="false">{{item.title}}</button>
+			<button class="collapsible" aria-expanded="false">{{item.title}}</button>
 			<div class="content" style="display:none">
 				<p>{{item.description}}</p>
 				<a href="{{url_for('download', id=item.id)}}">Download</a>


### PR DESCRIPTION
Replaced direct assignment to the object value with `setattribute` which works. I also removed `aria-controls` as no AT aside from JAWS supports it. Tested in Firefox and the new Edge based on Chromium. cc @jakubl7545 